### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,5 +1,8 @@
 name: Secret Scan
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Promplify/promplify-web/security/code-scanning/1](https://github.com/Promplify/promplify-web/security/code-scanning/1)

In general, the fix is to explicitly define a `permissions:` block to restrict the `GITHUB_TOKEN` to the minimum necessary scopes. For a read-only scanning workflow that checks out the repository and runs gitleaks in Docker, the minimal practical permission is `contents: read`, usually set at the workflow root so it applies to all jobs.

Concretely, in `.github/workflows/secret-scan.yml`, add a `permissions:` block near the top of the workflow, alongside `name:` and `on:`, specifying `contents: read`. This documents and enforces that the job can only read repository contents and cannot write to the repo, issues, or pull requests. No additional imports or methods are needed, since this is purely a YAML configuration change. We will not change the job’s steps or behavior; we will only add the permissions declaration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
