### PR TITLE
fix(sentry): filter react dom noise

### DIFF
--- a/src/lib/sentryNoise.ts
+++ b/src/lib/sentryNoise.ts
@@ -1,0 +1,58 @@
+type SentryStackFrame = {
+  filename?: string;
+  module?: string;
+  function?: string;
+  in_app?: boolean;
+};
+
+type SentryExceptionValue = {
+  type?: string;
+  value?: string;
+  stacktrace?: {
+    frames?: SentryStackFrame[];
+  };
+};
+
+type SentryEventLike = {
+  exception?: {
+    values?: SentryExceptionValue[];
+  };
+};
+
+type SentryHintLike = {
+  originalException?: unknown;
+};
+
+function isNotFoundDomException(value: unknown): boolean {
+  return (
+    typeof DOMException !== "undefined" &&
+    value instanceof DOMException &&
+    value.name === "NotFoundError"
+  );
+}
+
+function isReactDomFrame(frame: SentryStackFrame): boolean {
+  const source = `${frame.filename || ""} ${frame.module || ""} ${frame.function || ""}`.toLowerCase();
+  return source.includes("react-dom");
+}
+
+export function shouldDropReactRemoveChildNoise(event: SentryEventLike, hint?: SentryHintLike): boolean {
+  const exception = event.exception?.values?.[0];
+  const message = exception?.value || "";
+  const frames = exception?.stacktrace?.frames || [];
+  const isRemoveChildNotFound =
+    exception?.type === "NotFoundError" &&
+    message.includes("removeChild") &&
+    message.includes("not a child of this node");
+
+  if (!isRemoveChildNotFound && !isNotFoundDomException(hint?.originalException)) {
+    return false;
+  }
+
+  const hasApplicationFrame = frames.some((frame) => frame.in_app === true);
+  if (hasApplicationFrame) {
+    return false;
+  }
+
+  return frames.some(isReactDomFrame);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import * as Sentry from "@sentry/react";
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
+import { shouldDropReactRemoveChildNoise } from "./lib/sentryNoise";
 
 // Initialize Sentry (hardcoded DSN per request)
 const SENTRY_DSN = "https://792b1d5e0b71fc2444800289dd48bd9b@o4504698557693952.ingest.us.sentry.io/4509172418084864";
@@ -13,6 +14,13 @@ Sentry.init({
   // Session Replay disabled to avoid consuming reserved replay volume.
   replaysSessionSampleRate: 0,
   replaysOnErrorSampleRate: 0,
+  beforeSend(event, hint) {
+    if (shouldDropReactRemoveChildNoise(event, hint)) {
+      return null;
+    }
+
+    return event;
+  },
 });
 
 createRoot(document.getElementById("root")!).render(<App />);

--- a/tests/sentryNoise.test.mjs
+++ b/tests/sentryNoise.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { shouldDropReactRemoveChildNoise } from "../src/lib/sentryNoise.ts";
+
+const removeChildEvent = {
+  exception: {
+    values: [
+      {
+        type: "NotFoundError",
+        value: "Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+        stacktrace: {
+          frames: [
+            {
+              filename: "../../node_modules/react-dom/cjs/react-dom.production.min.js",
+              module: "react-dom/cjs/react-dom.production",
+              function: "Uc",
+              in_app: false
+            }
+          ]
+        }
+      }
+    ]
+  }
+};
+
+test("drops React DOM removeChild noise without application frames", () => {
+  assert.equal(shouldDropReactRemoveChildNoise(removeChildEvent), true);
+});
+
+test("keeps removeChild errors when application frames are present", () => {
+  const event = structuredClone(removeChildEvent);
+  event.exception.values[0].stacktrace.frames.push({
+    filename: "src/components/dashboard/PromptEditor.tsx",
+    module: "src.components.dashboard.PromptEditor",
+    function: "PromptEditor",
+    in_app: true
+  });
+
+  assert.equal(shouldDropReactRemoveChildNoise(event), false);
+});
+
+test("keeps unrelated DOM exceptions", () => {
+  const event = structuredClone(removeChildEvent);
+  event.exception.values[0].value = "ResizeObserver loop completed with undelivered notifications.";
+
+  assert.equal(shouldDropReactRemoveChildNoise(event), false);
+});


### PR DESCRIPTION
## Summary\n- filter React DOM removeChild NotFoundError noise when no app frames exist\n- add focused Sentry noise tests\n\n## Validation\n- npm run type-check\n- node --experimental-strip-types --test tests/sentryNoise.test.mjs